### PR TITLE
Fix picture

### DIFF
--- a/Frühstück/Pancakes.md
+++ b/Frühstück/Pancakes.md
@@ -20,4 +20,4 @@ Portionen: 12-16
 1. Die Pfanne auf mittlerer Stufe erhitzen, jeweils etwa einen TL Öl hineingeben und nacheinander den Teig zu Pancakes verbacken. Vier pro Pfanne. Wichtig! Ganz wenig Öl verwenden und langsam, also auf mittlerer Stufe nicht zu heiß ausbacken.
 
 *Schmecken toll mit Joghurt, Ahornsirup und Früchten*
-<img src="pancakes.jpg" width=300px>
+<img src="Pancakes.jpg" width=300px>


### PR DESCRIPTION
Das Bild für die Pancakes wurde nicht angezeigt.
Danke an @petrabuehh 
Sie hat in Issue: #30 gesehen, dass ich nicht auf die Groß- und Kleinschreibung geachtet habe.
So ist es, wenn man nur auf einem Win10 kontrolliert.